### PR TITLE
orphanRemoval = true 설정 시 문제

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,9 @@ dependencies {
 
 	//swagger
 	implementation 'io.springfox:springfox-boot-starter:3.0.0'
+
+	//쿼리 파라미터 로그 라이브러리
+	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.5.6'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/be1/plant4you/repository/CommentRepository.java
+++ b/src/main/java/com/be1/plant4you/repository/CommentRepository.java
@@ -2,6 +2,7 @@ package com.be1.plant4you.repository;
 
 import com.be1.plant4you.domain.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -9,6 +10,18 @@ import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
-    @Query("select cmt from Comment cmt where cmt.parent.id = :parentId")
-    List<Comment> findAllByParentId(@Param("parentId") Long parentId);
+    @Query("select cmt from Comment cmt where cmt.parent is null and cmt.post.id = :postId")
+    List<Comment> findAllParentByPostId(@Param("postId") Long postId);
+
+    @Modifying
+    @Query("delete from Comment cmt where cmt.parent.id = :parentId")
+    void deleteAllByParentId(@Param("parentId") Long parentId);
+
+    @Modifying
+    @Query("delete from Comment cmt where cmt.parent.id in :parentIds")
+    void deleteAllByParentIdsIn(@Param("parentIds") List<Long> parentIds);
+
+    @Modifying
+    @Query("delete from Comment cmt where cmt.parent.id is null and cmt.id in :ids")
+    void deleteAllParentByIdsIn(@Param("ids") List<Long> ids);
 }

--- a/src/main/java/com/be1/plant4you/repository/LikesRepository.java
+++ b/src/main/java/com/be1/plant4you/repository/LikesRepository.java
@@ -3,13 +3,13 @@ package com.be1.plant4you.repository;
 import com.be1.plant4you.common.LikesId;
 import com.be1.plant4you.domain.Likes;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
-
 public interface LikesRepository extends JpaRepository<Likes, LikesId> {
 
-    @Query("select l from Likes l where l.post.id = :postId")
-    List<Likes> findAllByPostId(@Param("postId") Long postId);
+    @Modifying
+    @Query("delete from Likes l where l.post.id = :postId")
+    void deleteAllByPostId(@Param("postId") Long postId);
 }

--- a/src/main/java/com/be1/plant4you/repository/ScrapRepository.java
+++ b/src/main/java/com/be1/plant4you/repository/ScrapRepository.java
@@ -3,13 +3,13 @@ package com.be1.plant4you.repository;
 import com.be1.plant4you.common.ScrapId;
 import com.be1.plant4you.domain.Scrap;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
-
 public interface ScrapRepository extends JpaRepository<Scrap, ScrapId> {
 
-    @Query("select s from Scrap s where s.post.id = :postId")
-    List<Scrap> findAllByPostId(@Param("postId") Long postId);
+    @Modifying
+    @Query("delete from Scrap s where s.post.id = :postId")
+    void deleteAllByPostId(@Param("postId") Long postId);
 }

--- a/src/main/java/com/be1/plant4you/repository/custom/PostRepositoryImpl.java
+++ b/src/main/java/com/be1/plant4you/repository/custom/PostRepositoryImpl.java
@@ -195,7 +195,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                 .join(comment.user, user)
                 .where(comment.post.id.eq(postId),
                         comment.parent.isNull())
-                .orderBy(comment.createdDate.desc())
+                .orderBy(comment.createdDate.asc())
                 .fetch();
         List<Long> parentIds = parentList.stream().map(CommentResponse::getCommentId).collect(Collectors.toList());
 
@@ -215,7 +215,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                 .from(comment)
                 .join(comment.user, user)
                 .where(comment.parent.id.in(parentIds))
-                .orderBy(comment.createdDate.desc())
+                .orderBy(comment.createdDate.asc())
                 .fetch();
         //댓글 별로 대댓글 그룹핑
         Map<Long, List<CommentResponse>> childListMap = childLists.stream().collect(

--- a/src/main/java/com/be1/plant4you/service/CommentService.java
+++ b/src/main/java/com/be1/plant4you/service/CommentService.java
@@ -11,7 +11,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -80,19 +79,18 @@ public class CommentService {
         Optional<Comment> commentOptional = commentRepository.findById(cmtId);
 
         //댓글이 존재하면서, 해당 댓글이 현재 로그인한 이용자가 쓴 댓글일 경우에만 삭제 가능
-        if (commentOptional.isPresent() && Objects.equals(commentOptional.get().getUser().getId(), userId)) {
+        if (commentOptional.isPresent()) {
             Comment comment = commentOptional.get();
-
-            //댓글이 경우 => 댓글, 연관된 대댓글 모두 삭제
-            if (comment.getParent() == null) {
-                List<Comment> childList = commentRepository.findAllByParentId(cmtId);
-
-                commentRepository.deleteAll(childList); //나중에 orphanRemoval = true 적용하기
-                commentRepository.delete(comment);
-            }
-            //대댓글일 경우 => is_delete = true
-            else {
-                comment.deleteCmt2();
+            if (Objects.equals(comment.getUser().getId(), userId)) {
+                //댓글이 경우 => 댓글, 연관된 대댓글 모두 삭제
+                if (comment.getParent() == null) {
+                    commentRepository.deleteAllByParentId(comment.getId()); //대댓글 삭제
+                    commentRepository.delete(comment); //댓글 삭제
+                }
+                //대댓글일 경우 => update is_delete = true
+                else {
+                    comment.deleteCmt2();
+                }
             }
         }
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,3 +3,6 @@ spring.profiles.include = db,oauth
 
 # swagger
 spring.mvc.pathmatch.matching-strategy=ant_path_matcher
+
+#batch 사이즈 설정
+spring.jpa.properties.hibernate.default_batch_fetch_size=100


### PR DESCRIPTION
### Post, Comment의 \@OneToMany 부분에 orphanRemoval = true 설정 시 문제점

<br>
 
**Post, Comment 삭제 시 관련 고아 객체 리스트 요소 각각에 대해 delete 쿼리가 나감**

즉 리스트의 요소 갯수가 5개라면, 리스트에 대해 delete in 쿼리 1번이 아닌, 5번의 delete 쿼리가 나감 (쿼리 too many)
문제 해결 못해서 일단 CommentRepository, LikesRepository, ScrapRepository에 직접 delete 쿼리 작성